### PR TITLE
[FLINK-34111] Add support for json_quote, json_unquote, address PR feedback

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -379,10 +379,10 @@ string:
     description: Returns a substring of string starting from position integer1 with length integer2 (to the end by default).
   - sql: JSON_QUOTE(string)
     table: STRING.JsonQuote()
-    description: Quotes a string as a JSON value by wrapping it with double quote characters, escaping interior quote and special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't'), and returning the result as a utf8mb4 string. If the argument is NULL, the function returns NULL.
+    description: Quotes a string as a JSON value by wrapping it with double quote characters, escaping interior quote and special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't'), and returning the result as a string. If the argument is NULL, the function returns NULL.
   - sql: JSON_UNQUOTE(string)
     table: STRING.JsonUnquote()
-    description: Unquotes JSON value, escapes special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a utf8mb4 string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
+    description: Unquotes JSON value, escapes special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
 
 temporal:
   - sql: DATE string

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -377,6 +377,12 @@ string:
   - sql: SUBSTR(string, integer1[, integer2])
     table: STRING.substr(INTEGER1[, INTEGER2])
     description: Returns a substring of string starting from position integer1 with length integer2 (to the end by default).
+  - sql: JSON_QUOTE(string)
+    table: STRING.JsonQuote()
+    description: Quotes a string as a JSON value by wrapping it with double quote characters, escaping interior quote and special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't'), and returning the result as a utf8mb4 string. If the argument is NULL, the function returns NULL.
+  - sql: JSON_UNQUOTE(string)
+    table: STRING.JsonUnquote()
+    description: Unquotes JSON value, escapes special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a utf8mb4 string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
 
 temporal:
   - sql: DATE string

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -305,3 +305,5 @@ JSON functions
     Expression.json_exists
     Expression.json_value
     Expression.json_query
+    Expression.json_quote
+    Expression.json_unquote

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -88,7 +88,8 @@ _string_doc_seealso = """
              :func:`~Expression.overlay`, :func:`~Expression.regexp_replace`,
              :func:`~Expression.regexp_extract`, :func:`~Expression.substring`,
              :py:attr:`~Expression.from_base64`, :py:attr:`~Expression.to_base64`,
-             :py:attr:`~Expression.ltrim`, :py:attr:`~Expression.rtrim`, :func:`~Expression.repeat`
+             :py:attr:`~Expression.ltrim`, :py:attr:`~Expression.rtrim`, :func:`~Expression.repeat`,
+             :func:`~Expression.json_quote`, :func:`~Expression.json_unquote`
 """
 
 _temporal_doc_seealso = """
@@ -186,7 +187,8 @@ def _make_string_doc():
         Expression.init_cap, Expression.like, Expression.similar, Expression.position,
         Expression.lpad, Expression.rpad, Expression.overlay, Expression.regexp_replace,
         Expression.regexp_extract, Expression.from_base64, Expression.to_base64,
-        Expression.ltrim, Expression.rtrim, Expression.repeat
+        Expression.ltrim, Expression.rtrim, Expression.repeat,
+        Expression.json_quote, Expression.json_unquote
     ]
 
     for func in string_funcs:

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -116,6 +116,8 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_NUL
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_TRUE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_EXISTS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_QUERY;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_QUOTE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_UNQUOTE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_VALUE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LAST_VALUE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LEFT;
@@ -1126,6 +1128,19 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType regexpExtract(InType regex) {
         return toApiSpecificExpression(
                 unresolvedCall(REGEXP_EXTRACT, toExpr(), objectToExpression(regex)));
+    }
+
+    /**
+     * Returns a string by quotes a string as a JSON value and wrapping it with double quote
+     * characters.
+     */
+    public OutType jsonQuote() {
+        return toApiSpecificExpression(unresolvedCall(JSON_QUOTE, objectToExpression(toExpr())));
+    }
+
+    /** Returns utf8mb4 string by unquoting JSON value. */
+    public OutType jsonUnquote() {
+        return toApiSpecificExpression(unresolvedCall(JSON_UNQUOTE, objectToExpression(toExpr())));
     }
 
     /** Returns the base string decoded with base64. */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1138,7 +1138,7 @@ public abstract class BaseExpressions<InType, OutType> {
         return toApiSpecificExpression(unresolvedCall(JSON_QUOTE, objectToExpression(toExpr())));
     }
 
-    /** Returns utf8mb4 string by unquoting JSON value. */
+    /** Returns a string by unquoting JSON value. */
     public OutType jsonUnquote() {
         return toApiSpecificExpression(unresolvedCall(JSON_UNQUOTE, objectToExpression(toExpr())));
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1085,6 +1085,24 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .build();
 
+    public static final BuiltInFunctionDefinition JSON_QUOTE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("JSON_QUOTE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.JsonQuoteFunction")
+                    .build();
+    public static final BuiltInFunctionDefinition JSON_UNQUOTE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("JSON_UNQUOTE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.JsonUnquoteFunction")
+                    .build();
     public static final BuiltInFunctionDefinition FROM_BASE64 =
             BuiltInFunctionDefinition.newBuilder()
                     .name("fromBase64")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -814,7 +814,8 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "This is a \t test \n with special characters: \" \\ \b \f \r \u0041",
                                 "\"special\": \"\\b\\f\\r\"",
                                 "\tThis quote\\ \" /",
-                                "this will not be quoted \\u006z")
+                                "this will not be quoted \\u006z",
+                                null)
                         .andDataTypes(
                                 STRING().notNull(),
                                 STRING().notNull(),
@@ -822,7 +823,8 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 STRING().notNull(),
                                 STRING().notNull(),
                                 STRING().notNull(),
-                                STRING().notNull())
+                                STRING().notNull(),
+                                STRING().nullable())
                         .testResult(
                                 $("f0").jsonQuote(), "JSON_QUOTE(f0)", "\"V\"", STRING().notNull())
                         .testResult(
@@ -854,7 +856,9 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f6").jsonQuote(),
                                 "JSON_QUOTE(f6)",
                                 "\"this will not be quoted \\\\u006z\"",
-                                STRING().notNull()));
+                                STRING().notNull())
+                        .testResult(
+                                $("f7").jsonQuote(), "JSON_QUOTE(f7)", null, STRING().nullable()));
     }
 
     private static List<TestSetSpec> jsonUnquoteSpec() {
@@ -881,8 +885,12 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "\"\"\"",
                                 "\"\"hg\"",
                                 "\"a unicode \u2260\"",
-                                "\"invalid unicode \\u006z\"")
+                                "\"invalid json string passthrough \\u006z\"",
+                                "\"invalid unicode literal \\u23\"",
+                                "\"invalid unicode literal \\u≠FFF\"")
                         .andDataTypes(
+                                STRING().notNull(),
+                                STRING().notNull(),
                                 STRING().notNull(),
                                 STRING().notNull(),
                                 STRING().notNull(),
@@ -950,7 +958,17 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f12").jsonUnquote(),
                                 "JSON_UNQUOTE(f12)",
-                                "\"invalid unicode \\u006z\"",
+                                "\"invalid json string passthrough \\u006z\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f13").jsonUnquote(),
+                                "JSON_UNQUOTE(f13)",
+                                "\"invalid unicode literal \\u23\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f14").jsonUnquote(),
+                                "JSON_UNQUOTE(f14)",
+                                "\"invalid unicode literal \\u≠FFF\"",
                                 STRING().notNull()));
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -88,6 +88,8 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
         testCases.addAll(jsonStringSpec());
         testCases.addAll(jsonObjectSpec());
         testCases.addAll(jsonArraySpec());
+        testCases.addAll(jsonQuoteSpec());
+        testCases.addAll(jsonUnquoteSpec());
 
         return testCases.stream();
     }
@@ -791,6 +793,164 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         + "\"R\":{\"f0\":\"V\",\"f1\":null}"
                                         + "}",
                                 STRING().notNull(),
+                                STRING().notNull()));
+    }
+
+    private static List<TestSetSpec> jsonQuoteSpec() {
+
+        return Arrays.asList(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUOTE)
+                        .onFieldsWithData(0)
+                        .testResult(
+                                nullOf(STRING()).jsonQuote(),
+                                "JSON_QUOTE(CAST(NULL AS STRING))",
+                                null,
+                                STRING().nullable()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUOTE)
+                        .onFieldsWithData(
+                                "V",
+                                "\"null\"",
+                                "[1, 2, 3]",
+                                "This is a \t test \n with special characters: \" \\ \b \f \r \u0041",
+                                "\"special\": \"\\b\\f\\r\"",
+                                "\tThis quote\\ \" /",
+                                "this will not be quoted \\u006z")
+                        .andDataTypes(
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull())
+                        .testResult(
+                                $("f0").jsonQuote(), "JSON_QUOTE(f0)", "\"V\"", STRING().notNull())
+                        .testResult(
+                                $("f1").jsonQuote(),
+                                "JSON_QUOTE(f1)",
+                                "\"\\\"null\\\"\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f2").jsonQuote(),
+                                "JSON_QUOTE(f2)",
+                                "\"[1, 2, 3]\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f3").jsonQuote(),
+                                "JSON_QUOTE(f3)",
+                                "\"This is a \\t test \\n with special characters: \\\" \\\\ \\b \\f \\r A\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f4").jsonQuote(),
+                                "JSON_QUOTE(f4)",
+                                "\"\\\"special\\\": \\\"\\\\b\\\\f\\\\r\\\"\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f5").jsonQuote(),
+                                "JSON_QUOTE(f5)",
+                                "\"\\tThis quote\\\\ \\\" \\/\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f6").jsonQuote(),
+                                "JSON_QUOTE(f6)",
+                                "\"this will not be quoted \\\\u006z\"",
+                                STRING().notNull()));
+    }
+
+    private static List<TestSetSpec> jsonUnquoteSpec() {
+
+        return Arrays.asList(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_UNQUOTE)
+                        .onFieldsWithData(0)
+                        .testResult(
+                                nullOf(STRING()).jsonQuote(),
+                                "JSON_UNQUOTE(CAST(NULL AS STRING))",
+                                null,
+                                STRING().nullable()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_UNQUOTE)
+                        .onFieldsWithData(
+                                "\"abc\"",
+                                "\"[\"abc\"]\"",
+                                "\"[\"\\u0041\"]\"",
+                                "\"\\u0041\"",
+                                "\"[1,2,3]",
+                                "\"[1, 2, 3}",
+                                "\"",
+                                "\"[\"\\t\\u0032\"]\"",
+                                "\"[\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"]\"",
+                                "\"\"\"",
+                                "\"\"hg\"",
+                                "\"a unicode \u2260\"",
+                                "\"invalid unicode \\u006z\"")
+                        .andDataTypes(
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull())
+                        .testResult(
+                                $("f0").jsonUnquote(),
+                                "JSON_UNQUOTE(f0)",
+                                "abc",
+                                STRING().notNull())
+                        .testResult(
+                                $("f1").jsonUnquote(),
+                                "JSON_UNQUOTE(f1)",
+                                "[\"abc\"]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f2").jsonUnquote(),
+                                "JSON_UNQUOTE(f2)",
+                                "[\"A\"]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f3").jsonUnquote(), "JSON_UNQUOTE(f3)", "A", STRING().notNull())
+                        .testResult(
+                                $("f4").jsonUnquote(),
+                                "JSON_UNQUOTE(f4)",
+                                "\"[1,2,3]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f5").jsonUnquote(),
+                                "JSON_UNQUOTE(f5)",
+                                "\"[1, 2, 3}",
+                                STRING().notNull())
+                        .testResult(
+                                $("f6").jsonUnquote(), "JSON_UNQUOTE(f6)", "\"", STRING().notNull())
+                        .testResult(
+                                $("f7").jsonUnquote(),
+                                "JSON_UNQUOTE(f7)",
+                                "[\"\t2\"]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f8").jsonUnquote(),
+                                "JSON_UNQUOTE(f8)",
+                                "[\"This is a \t test \n with special characters: \b \f \r A\"]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f9").jsonUnquote(), "JSON_UNQUOTE(f9)", "\"", STRING().notNull())
+                        .testResult(
+                                $("f10").jsonUnquote(),
+                                "JSON_UNQUOTE(f10)",
+                                "\"hg",
+                                STRING().notNull())
+                        .testResult(
+                                $("f11").jsonUnquote(),
+                                "JSON_UNQUOTE(f11)",
+                                "a unicode ≠",
+                                STRING().notNull())
+                        .testResult(
+                                $("f12").jsonUnquote(),
+                                "JSON_UNQUOTE(f12)",
+                                "\"invalid unicode \\u006z\"",
                                 STRING().notNull()));
     }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -607,17 +607,16 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testJsonQuote(): Unit = {
     testSqlApi("JSON_QUOTE('null')", "\"null\"")
-    testSqlApi("JSON_QUOTE('\"null\"')", "\"\"null\"\"")
+    testSqlApi("JSON_QUOTE('\"null\"')", "\"\\\"null\\\"\"")
     testSqlApi("JSON_QUOTE('[1,2,3]')", "\"[1,2,3]\"")
     testSqlApi("JSON_UNQUOTE(JSON_QUOTE('[1,2,3]'))", "[1,2,3]")
     testSqlApi(
       "JSON_QUOTE('This is a \\t test \\n with special characters: \" \\ \\b \\f \\r \\u0041')",
-      "\"This is a \\t test \\n with special characters: \" \\ \\b \\f \\r \\u0041\""
+      "\"This is a \\\\t test \\\\n with special characters: \\\" \\\\ \\\\b \\\\f \\\\r \\\\u0041\""
     )
     testSqlApi(
       "JSON_QUOTE('\"special\": \"\\b\\f\\r\"')",
-      "\"\"special\": \"\\b\\f\\r\"\""
-    )
+      "\"\\\"special\\\": \\\"\\\\b\\\\f\\\\r\\\"\"")
     testSqlApi(
       "JSON_QUOTE('skipping backslash \')",
       "\"skipping backslash \""
@@ -635,14 +634,10 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}')", "\"[1, 2, 3}")
     testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}\"')", "[1, 2, 3}")
     testSqlApi("JSON_UNQUOTE('\"')", "\"")
-    testSqlApi("JSON_UNQUOTE('\"[\\t\\u0032]\"')", "[\\t2]")
+    testSqlApi("JSON_UNQUOTE('\"[\\t\\u0032]\"')", "[\t2]")
     testSqlApi(
       "JSON_UNQUOTE('\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"')",
       "This is a \\t test \\n with special characters: \\b \\f \\r A"
-    )
-    testSqlApi(
-      "JSON_UNQUOTE('\"[\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"]\"')",
-      "[\"This is a \\t test \\n with special characters: \\b \\f \\r A\"]"
     )
     testSqlApi("json_unquote(json_quote('\"key\"'))", "\"key\"")
     testSqlApi("json_unquote(json_quote('\"[]\"'))", "\"[]\"")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -605,6 +605,50 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
+  def testJsonQuote(): Unit = {
+    testSqlApi("JSON_QUOTE('null')", "\"null\"")
+    testSqlApi("JSON_QUOTE('\"null\"')", "\"\"null\"\"")
+    testSqlApi("JSON_QUOTE('[1,2,3]')", "\"[1,2,3]\"")
+    testSqlApi("JSON_UNQUOTE(JSON_QUOTE('[1,2,3]'))", "[1,2,3]")
+    testSqlApi(
+      "JSON_QUOTE('This is a \\t test \\n with special characters: \" \\ \\b \\f \\r \\u0041')",
+      "\"This is a \\t test \\n with special characters: \" \\ \\b \\f \\r \\u0041\""
+    )
+    testSqlApi(
+      "JSON_QUOTE('\"special\": \"\\b\\f\\r\"')",
+      "\"\"special\": \"\\b\\f\\r\"\""
+    )
+    testSqlApi(
+      "JSON_QUOTE('skipping backslash \')",
+      "\"skipping backslash \""
+    )
+  }
+
+  @Test
+  def testJsonUnquote(): Unit = {
+    testSqlApi("JSON_UNQUOTE('\"abc\"')", "abc")
+    testSqlApi("JSON_UNQUOTE('\"[abc]\"')", "[abc]")
+    testSqlApi("JSON_UNQUOTE('\"[abc}\"')", "[abc}")
+    testSqlApi("JSON_UNQUOTE('\"[\\u0041]\"')", "[A]")
+    testSqlApi("JSON_UNQUOTE('\"[\\u006z]\"')", "\"[\\u006z]\"")
+    testSqlApi("JSON_UNQUOTE('\"[1,2,3]')", "\"[1,2,3]")
+    testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}')", "\"[1, 2, 3}")
+    testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}\"')", "[1, 2, 3}")
+    testSqlApi("JSON_UNQUOTE('\"')", "\"")
+    testSqlApi("JSON_UNQUOTE('\"[\\t\\u0032]\"')", "[\\t2]")
+    testSqlApi(
+      "JSON_UNQUOTE('\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"')",
+      "This is a \\t test \\n with special characters: \\b \\f \\r A"
+    )
+    testSqlApi(
+      "JSON_UNQUOTE('\"[\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"]\"')",
+      "[\"This is a \\t test \\n with special characters: \\b \\f \\r A\"]"
+    )
+    testSqlApi("json_unquote(json_quote('\"key\"'))", "\"key\"")
+    testSqlApi("json_unquote(json_quote('\"[]\"'))", "\"[]\"")
+  }
+
+  @Test
   def testFromBase64(): Unit = {
     testSqlApi("FROM_BASE64('aGVsbG8gd29ybGQ=')", "hello world")
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#JSON_QUOTE}. */
+@Internal
+public class JsonQuoteFunction extends BuiltInScalarFunction {
+
+    public JsonQuoteFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.JSON_QUOTE, context);
+    }
+
+    private static String quote(String input) {
+        StringBuilder outputStr = new StringBuilder();
+
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            switch (ch) {
+                case '"':
+                    outputStr.append("\\\"");
+                    break;
+                case '\\':
+                    outputStr.append("\\\\");
+                    break;
+                case '/':
+                    outputStr.append("\\/");
+                    break;
+                case '\b':
+                    outputStr.append("\\b");
+                    break;
+                case '\f':
+                    outputStr.append("\\f");
+                    break;
+                case '\n':
+                    outputStr.append("\\n");
+                    break;
+                case '\r':
+                    outputStr.append("\\r");
+                    break;
+                case '\t':
+                    outputStr.append("\\t");
+                    break;
+                default:
+                    outputStr.append(unicodeLiteralOrStr(ch));
+            }
+        }
+        return outputStr.toString();
+    }
+
+    public static String unicodeLiteralOrStr(char ch) {
+        if (ch > 127) {
+            return String.format("\\u%04x", ch);
+        } else {
+            return String.valueOf(ch);
+        }
+    }
+
+    public @Nullable Object eval(Object input) {
+        if (input == null) {
+            return null;
+        }
+        BinaryStringData bs = (BinaryStringData) input;
+        String stringWithoutQuotes = quote(bs.toString());
+        String outputVal = String.format("\"%s\"", stringWithoutQuotes);
+        return new BinaryStringData(outputVal);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
@@ -64,13 +64,13 @@ public class JsonQuoteFunction extends BuiltInScalarFunction {
                     outputStr.append("\\t");
                     break;
                 default:
-                    outputStr.append(unicodeLiteralOrStr(ch));
+                    outputStr.append(formatStr(ch));
             }
         }
         return outputStr.toString();
     }
 
-    public static String unicodeLiteralOrStr(char ch) {
+    private static String formatStr(char ch) {
         if (ch > 127) {
             return String.format("\\u%04x", ch);
         } else {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.runtime.functions.SqlJsonUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#JSON_UNQUOTE}. */
+@Internal
+public class JsonUnquoteFunction extends BuiltInScalarFunction {
+
+    public JsonUnquoteFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.JSON_UNQUOTE, context);
+    }
+
+    private static boolean isValidJsonVal(String jsonInString) {
+        return SqlJsonUtils.isJsonValue(jsonInString);
+    }
+
+    private String unquote(String inputStr) {
+
+        StringBuilder result = new StringBuilder();
+        int i = 1;
+        while (i < inputStr.length() - 1) {
+            if (inputStr.charAt(i) == '\\' && i + 1 < inputStr.length()) {
+                i++; // move to the next char
+                char charAfterBackSlash = inputStr.charAt(i++);
+
+                switch (charAfterBackSlash) {
+                    case '"':
+                        result.append(charAfterBackSlash);
+                        break;
+                    case '\\':
+                        result.append(charAfterBackSlash);
+                        break;
+                    case '/':
+                        result.append(charAfterBackSlash);
+                        break;
+                    case 'b':
+                        result.append('\b');
+                        break;
+                    case 'f':
+                        result.append('\f');
+                        break;
+                    case 'n':
+                        result.append('\n');
+                        break;
+                    case 'r':
+                        result.append('\r');
+                        break;
+                    case 't':
+                        result.append('\t');
+                        break;
+                    case 'u':
+                        result.append(fromUnicodeLiteral(inputStr, i));
+                        i = i + 4;
+                        break;
+                    default:
+                        throw new RuntimeException(
+                                "Illegal escape sequence: \\" + charAfterBackSlash);
+                }
+            } else {
+                result.append(inputStr.charAt(i));
+                i++;
+            }
+        }
+        return result.toString();
+    }
+
+    private static String fromUnicodeLiteral(String input, int curPos) {
+
+        StringBuilder number = new StringBuilder();
+        if (curPos + 4 > input.length()) {
+            throw new RuntimeException("Not enough unicode digits!");
+        }
+        for (char ch : input.substring(curPos, curPos + 4).toCharArray()) {
+            if (!Character.isLetterOrDigit(ch)) {
+                throw new RuntimeException("Bad character in unicode escape.");
+            }
+            number.append(Character.toLowerCase(ch));
+        }
+        int code = Integer.parseInt(number.toString(), 16);
+        return String.valueOf((char) code);
+    }
+
+    public @Nullable Object eval(Object input) {
+
+        try {
+            if (input == null) {
+                return null;
+            }
+            BinaryStringData bs = (BinaryStringData) input;
+            String inputStr = bs.toString();
+            if (isValidJsonVal(inputStr)) {
+                return new BinaryStringData(unquote(inputStr));
+            } else {
+                // return input as is since JSON is invalid
+                return new BinaryStringData(inputStr);
+            }
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
@@ -36,6 +36,7 @@ public class JsonUnquoteFunction extends BuiltInScalarFunction {
     }
 
     private static boolean isValidJsonVal(String jsonInString) {
+        // See also BuiltInMethods.scala, IS_JSON_VALUE
         return SqlJsonUtils.isJsonValue(jsonInString);
     }
 
@@ -92,13 +93,9 @@ public class JsonUnquoteFunction extends BuiltInScalarFunction {
     private static String fromUnicodeLiteral(String input, int curPos) {
 
         StringBuilder number = new StringBuilder();
-        if (curPos + 4 > input.length()) {
-            throw new RuntimeException("Not enough unicode digits!");
-        }
+        // isValidJsonVal will already check for unicode literal length >=4 and valid digit
+        // composition
         for (char ch : input.substring(curPos, curPos + 4).toCharArray()) {
-            if (!Character.isLetterOrDigit(ch)) {
-                throw new RuntimeException("Bad character in unicode escape.");
-            }
             number.append(Character.toLowerCase(ch));
         }
         int code = Integer.parseInt(number.toString(), 16);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
@@ -47,17 +47,17 @@ public class JsonUnquoteFunction extends BuiltInScalarFunction {
         while (i < inputStr.length() - 1) {
             if (inputStr.charAt(i) == '\\' && i + 1 < inputStr.length()) {
                 i++; // move to the next char
-                char charAfterBackSlash = inputStr.charAt(i++);
+                char ch = inputStr.charAt(i++);
 
-                switch (charAfterBackSlash) {
+                switch (ch) {
                     case '"':
-                        result.append(charAfterBackSlash);
+                        result.append(ch);
                         break;
                     case '\\':
-                        result.append(charAfterBackSlash);
+                        result.append(ch);
                         break;
                     case '/':
-                        result.append(charAfterBackSlash);
+                        result.append(ch);
                         break;
                     case 'b':
                         result.append('\b');
@@ -80,7 +80,7 @@ public class JsonUnquoteFunction extends BuiltInScalarFunction {
                         break;
                     default:
                         throw new RuntimeException(
-                                "Illegal escape sequence: \\" + charAfterBackSlash);
+                                "Illegal escape sequence: \\" + ch);
                 }
             } else {
                 result.append(inputStr.charAt(i));
@@ -93,8 +93,7 @@ public class JsonUnquoteFunction extends BuiltInScalarFunction {
     private static String fromUnicodeLiteral(String input, int curPos) {
 
         StringBuilder number = new StringBuilder();
-        // isValidJsonVal will already check for unicode literal length >=4 and valid digit
-        // composition
+        // isValidJsonVal will already check for unicode literal validity
         for (char ch : input.substring(curPos, curPos + 4).toCharArray()) {
             number.append(Character.toLowerCase(ch));
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Adds implementation of `json_quote` and `json_unquote` functions.
PR is a continuation of https://github.com/apache/flink/pull/24156 and addresses feedback received on the original PR.


## Brief change log / changes compared to PR 24156

- Update implementation for `json_quote` with escaping logic
- Update implementation for `json_unquote` to unescape special characters
  - Delegates valid json checking to SqlJsonUtils#isJsonValue
- Add/ update some additional tests
- Updates documentation to remove reference to MySql utf8mb4 encoding


## Open questions
- High level behavior for invalid json in json_unquote (pass original input as is, Vs throwing exception) 
- To check for JSON_VALIDITY for `json_unquote` logic for `IS JSON` is used but in certain cases `IS JSON` behaviour does not seem to be consistent with Json spec as documented here https://www.json.org/json-en.html 
  - According to json spec `""""` should not be a valid json (which is also supported by JsonLint) but `select '""""' IS JSON` returns true 
       -  In case of invalid json string for json_unquote an exception is thrown in case of Mysql (However we won't do the same) 


### References
- postgres implementation for [escape](https://github.com/postgres/postgres/blob/524d64ea8e3e49b4fda41ff9b2f048b697384058/src/backend/utils/adt/json.c#L2458) 

## Verifying this change

- Added ITs in JsonFunctionsITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
